### PR TITLE
version 0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,30 +7,41 @@ lxml2json is a python package that converts XML elements into their JSON equival
         from lxml2json import convert
         from pprint import pprint as pp
 
-        xml = """
-          <parent>
-            <child>1</child>
-            <child>2</child>
-            <child>3</child>
-          </parent>"""
+        xml = '''
+        <parent>
+            <c1>a</c1>
+            <c1>b</c1>
+            <c1>c</c1>
+            <c2>
+                <gc1>d</gc1>
+                <gc2>e</gc2>
+                <gc3>f</gc3>
+            </c2>
+            <c2>
+                <gc1>g</gc1>
+                <gc2>h</gc2>
+                <gc3>i</gc3>
+            </c2>
+            <c3>
+                <gc1>j</gc1>
+                <gc1>k</gc1>
+                <gc1>l</gc1>
+            </c3>
+            <c4/>
+        </parent>'''
 
         d = convert(xml)
         pp(d)
-        {'parent': {'child': ['1', '2', '3']}}
+        {'parent': {'c1': ['a', 'b', 'c'],
+                    'c2': [{'gc1': 'd', 'gc2': 'e', 'gc3': 'f'},
+                           {'gc1': 'g', 'gc2': 'h', 'gc3': 'i'}],
+                    'c3': {'gc1': ['j', 'k', 'l']},
+                    'c4': None}}
         
-        d = convert(xml, noCombine=True)
-        pp(d)
-        {'parent': [{'child': '1'}, {'child': '2'}, {'child': '3'}]}
-        
-        d = convert(xml, noCombine=True, ordered=True)
-        pp(d)
-        OrderedDict([('parent', [OrderedDict([('child', '1')]), OrderedDict([('child', '2')]), OrderedDict([('child', '3')])])])
 
-            
 ### Options
 
 lxml2json provides the following optional arguments to modify conversion behavior or output data format:
 
 -  **ordered:** Boolean, defaults to False. Specifies whether to generate output an OrderedDict object.
 -  **noText:** Defaults to None. Specifies the value to give to elements that contain no children and no text value.
--  **noCombine:** Defaults to False. Specifies whether or not to consolidate similar child elements' text values into a list. Accepts a list of tag values to exclude from consolidation, or when set to True, does not attempt to consolidate at all.

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="lxml2json",
-    version="0.1.0",
+    version="0.2.0",
     author="Robert Parelius",
     author_email="rparelius@gmail.com",
     description="converts XML elements into their JSON equivalent",


### PR DESCRIPTION
version 0.2.0 significantly changes the iteration logic from version 0.1.0.  Instead of creating a parent container for its child elements to define themselves within, in version 0.2.0 each element creates the json structure for all of its children. This has the advantages, such as scoping list creation to only elements that require it themselves. 